### PR TITLE
feat: add IBN commissioning commands for Mobilegate channel/room renaming

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -29,8 +29,11 @@
       "uk": "Статус на сервери",
       "zh-cn": "Steuert Jung/Gira eNet Smarthome-Geräte über das eNet 移动门 Funk IP Gateway oder dem eNet 智能主服务器"
     },
-    "version": "2.0.10",
+    "version": "2.0.11",
     "news": {
+      "2.0.11": {
+        "en": "#### Gateway version\n* Added IBN commissioning commands: ibnStart(), ibnEnd(), ibnEditChannel(), ibnEditRoom()\n* Allows renaming channels and rooms on the Mobilegate without the eNet app\n* Verified against Mobilegate firmware 0.91"
+      },
       "2.0.10": {
         "en": "#### Server version\n* added clearTimeout in main.js\n* added username as encryptedNative,-> please input username once again\n* added script package.json\n\n#### Gateway version\n* fixed warnings from Issue#86, -> please remove object tree before first start",
         "de": "oder Serverversion\n* deutlich hinzugefügt Zeit im Haupt. j)\n* Benutzername als verschlüsselt hinzugefügtNative,-> bitte Benutzername erneut eingeben\n* script-paket hinzugefügt. json\n\nGateway-Version\n* Feste Warnungen aus Ausgabe #86, -> bitte entfernen Objektbaum vor dem ersten Start",

--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -268,6 +268,128 @@ this.connect();
 }
 
 
+////////////////////////////////////////////////////////////////////////////////
+//
+//  IBN commissioning commands
+//
+//  IBN (Inbetriebnahme = commissioning) commands allow renaming channels and
+//  rooms on the Mobilegate. A session must be opened with ibnStart() and
+//  closed with ibnEnd() around any edit commands.
+//
+//  Verified against firmware 0.91 (Mobilegate hardware 73355700).
+//
+//  Important notes discovered through hardware testing:
+//  - VISIBLE in IBN_LIST_EDIT_REQ must be integer 1 or 0, NOT boolean true/false
+//  - ITEMS in IBN_LIST_EDIT_REQ must be a JSON array, even if empty
+//  - ICON is required in both IBN_EDIT_REQ and IBN_LIST_EDIT_REQ
+//
+
+/**
+ * Start an IBN commissioning session.
+ * Must be called before any ibnEditChannel/ibnEditRoom calls.
+ * @param {number} sessionNumber - Session handle (use the gateway/project number from PROJECT_LIST_GET)
+ * @param {string} password - IBN password (default "0000")
+ * @param {function} callback - Called with (err, msg) on IBN_PROGRAM_RES
+ */
+gateway.prototype.ibnStart = function(sessionNumber, password, callback) {
+    if (callback) {
+        new responseListener(this, "IBN_PROGRAM_RES", callback);
+    }
+    if (!this.connected) {
+        this.connect();
+    }
+    var msg = `{"CMD":"IBN_PROGRAM_REQ","PROTOCOL":"0.03","TIMESTAMP":"${Math.floor(Date.now()/1000)}","NUMBER":${sessionNumber},"PWD":"${password}"}\r\n\r\n`;
+    this.client.write(msg);
+// response: {"PROTOCOL":"0.03","TIMESTAMP":"...","CMD":"IBN_PROGRAM_RES","STATE":0}
+}
+
+/**
+ * End an IBN commissioning session.
+ * Must be called after all edit commands to save changes to the Mobilegate.
+ * @param {number} sessionNumber - Same session handle used in ibnStart()
+ * @param {function} callback - Called with (err, msg) on IBN_DONE_RES
+ */
+gateway.prototype.ibnEnd = function(sessionNumber, callback) {
+    if (callback) {
+        new responseListener(this, "IBN_DONE_RES", callback);
+    }
+    if (!this.connected) {
+        this.connect();
+    }
+    var msg = `{"CMD":"IBN_DONE_REQ","PROTOCOL":"0.03","TIMESTAMP":"${Math.floor(Date.now()/1000)}","NUMBER":${sessionNumber}}\r\n\r\n`;
+    this.client.write(msg);
+// response: {"PROTOCOL":"0.03","TIMESTAMP":"...","CMD":"IBN_DONE_RES","STATE":0}
+}
+
+/**
+ * Rename a channel (thing) on the Mobilegate.
+ * Must be called within an active IBN session (between ibnStart and ibnEnd).
+ * @param {number} number - Channel number (16-39)
+ * @param {string} name - New display name
+ * @param {string} type - Channel type string e.g. "Jalousie", "Dimmer", "Binaer", "Szene"
+ * @param {number[]} listNumbers - Array of room numbers this channel belongs to
+ * @param {object} [options] - Optional fields: writeable, readable, dimmable (0 or 1)
+ * @param {function} callback - Called with (err, msg) on IBN_EDIT_RES
+ */
+gateway.prototype.ibnEditChannel = function(number, name, type, listNumbers, options, callback) {
+    if (typeof options === 'function') {
+        callback = options;
+        options = {};
+    }
+    options = options || {};
+    if (callback) {
+        new responseListener(this, "IBN_EDIT_RES", callback);
+    }
+    if (!this.connected) {
+        this.connect();
+    }
+    var payload = {
+        CMD: "IBN_EDIT_REQ",
+        PROTOCOL: "0.03",
+        TIMESTAMP: Math.floor(Date.now()/1000).toString(),
+        NUMBER: number,
+        NAME: name,
+        TYPE: type,
+        LIST: listNumbers
+    };
+    if (options.writeable !== undefined) payload.WRITEABLE = options.writeable;
+    if (options.readable  !== undefined) payload.READABLE  = options.readable;
+    if (options.dimmable  !== undefined) payload.DIMMABLE  = options.dimmable;
+    this.client.write(JSON.stringify(payload) + "\r\n\r\n");
+// response: {"PROTOCOL":"0.03","TIMESTAMP":"...","CMD":"IBN_EDIT_RES","STATE":0}
+}
+
+/**
+ * Rename a room (list) on the Mobilegate.
+ * Must be called within an active IBN session (between ibnStart and ibnEnd).
+ * @param {number} number - Room number from PROJECT_LIST_GET LISTS array
+ * @param {string} name - New display name
+ * @param {number} icon - Icon code (integer, from PROJECT_LIST_GET ICON field)
+ * @param {number} visible - Visibility: 1 = visible, 0 = hidden (must be integer, NOT boolean)
+ * @param {number[]} items - Array of channel numbers assigned to this room
+ * @param {function} callback - Called with (err, msg) on IBN_LIST_EDIT_RES
+ */
+gateway.prototype.ibnEditRoom = function(number, name, icon, visible, items, callback) {
+    if (callback) {
+        new responseListener(this, "IBN_LIST_EDIT_RES", callback);
+    }
+    if (!this.connected) {
+        this.connect();
+    }
+    var payload = {
+        CMD: "IBN_LIST_EDIT_REQ",
+        PROTOCOL: "0.03",
+        TIMESTAMP: Math.floor(Date.now()/1000).toString(),
+        NUMBER: number,
+        NAME: name,
+        ICON: icon,
+        VISIBLE: visible ? 1 : 0,
+        ITEMS: items
+    };
+    this.client.write(JSON.stringify(payload) + "\r\n\r\n");
+// response: {"PROTOCOL":"0.03","TIMESTAMP":"...","CMD":"IBN_LIST_EDIT_RES","STATE":0}
+}
+
 function responseListener(gateway, response, callback) {
     this.gateway = gateway;
 

--- a/package.json
+++ b/package.json
@@ -64,5 +64,5 @@
     "release-minor": "release-script minor --yes",
     "release-major": "release-script major --yes"
   },
-  "version": "2.0.10"
+  "version": "2.0.11"
 }


### PR DESCRIPTION
## Summary

Adds IBN (Inbetriebnahme/commissioning) commands to `lib/gateway.js` that allow renaming channels and rooms directly on the Mobilegate via TCP port 9050, without requiring the eNet app.

### New methods

- **`ibnStart(sessionNumber, password, callback)`** — opens an IBN session (`IBN_PROGRAM_REQ`)
- **`ibnEnd(sessionNumber, callback)`** — closes the session and saves changes (`IBN_DONE_REQ`)
- **`ibnEditChannel(number, name, type, listNumbers, options, callback)`** — renames a channel (`IBN_EDIT_REQ`)
- **`ibnEditRoom(number, name, icon, visible, items, callback)`** — renames a room/list (`IBN_LIST_EDIT_REQ`)

### Usage

```js
const gw = eNet.gateway({ host: '192.168.178.34' });
gw.connect();

gw.ibnStart(40, '0000', (err, res) => {
    gw.ibnEditChannel(24, 'Rollo Lea', 'Jalousie', [5], {}, (err, res) => {
        gw.ibnEditRoom(7, 'Pauls Zimmer', 34, 1, [25], (err, res) => {
            gw.ibnEnd(40, (err, res) => {
                gw.disconnect();
            });
        });
    });
});
```

### Findings from hardware testing

Verified against Mobilegate firmware **0.91** (hardware `73355700`). Key protocol details documented in code comments:

- `VISIBLE` in `IBN_LIST_EDIT_REQ` must be **integer** `1` or `0` — sending boolean `true` returns `STATE:-12` (value error)
- `ITEMS` array is always required in `IBN_LIST_EDIT_REQ`, even if empty — omitting it returns `STATE:-13` (field absent)
- `ICON` field is required in both edit commands
- The `LIST` field in `IBN_EDIT_REQ` is an array of room numbers the channel belongs to (derived from `PROJECT_LIST_GET`)

These findings were cross-referenced against the decompiled Java source of the official eNet Android app (`de.gira.enet.mobilegate`).